### PR TITLE
added method to compute CCFs for many spectra in one go

### DIFF
--- a/src/ccf/calc_ccf.jl
+++ b/src/ccf/calc_ccf.jl
@@ -306,10 +306,8 @@ function ccf_1D_test(λ::A2, flux::A3,
         return ccf_out
     end
 
-    ccf_temp = zeros(len_v_grid)
     for i in 1:size(flux, 2)
-        ccf_1D!(ccf_temp, λ, flux[:,i], plan)
-        ccf_out[:,i] = ccf_temp
+        ccf_1D!(view(ccf_out, :, i), λ, view(flux, :, i), plan)
     end
     return ccf_out
 end

--- a/src/ccf/calc_ccf.jl
+++ b/src/ccf/calc_ccf.jl
@@ -282,6 +282,38 @@ function ccf_1D(λ::A2, flux::A3, #line_list::ALL, #mask_shape1::A3
 end
 
 """
+    `ccf_1D( λs, fluxes; ccf_plan )`
+    Compute the cross correlation functions of spectra with a mask.
+# Inputs:
+- `λs`: 1-d array of wavelengths
+- `fluxes`:  2-d array of fluxes, individual spectra along first dim
+# Optional Arguments:
+- `ccf_plan`:  parameters for computing ccf (BasicCCFPlan())
+# Returns:
+- 2-d array of size (length(calc_ccf_v_grid(plan)), size(flux, 2))
+"""
+function ccf_1D(λ::A2, flux::A3, #line_list::ALL, #mask_shape1::A3
+                plan::PlanT = BasicCCFPlan() ) where {
+                #; mask_shape::ACMS = TopHatCCFMask(), plan::PlanT = BasicCCFPlan() ) where {
+                T1<:Real, A1<:AbstractArray{T1,1}, T2<:Real, A2<:AbstractArray{T2,1}, T3<:Real, A3<:AbstractArray{T3,2},
+                #ALL<:AbstractLineList, ACMS<:AbstractCCFMaskShape, AP<:AbstractCCFPlan }
+                PlanT<:AbstractCCFPlan } # ALL<:AbstractLineList, ACMS<:AbstractCCFMaskShape }
+    @assert ndims(λ) == 1
+    @assert ndims(flux) == 2
+    @assert length(λ) == size(flux, 1)
+    len_v_grid = calc_length_ccf_v_grid(plan)
+    ccf_out = zeros(len_v_grid, size(flux, 2))
+    if length(plan.line_list) < 1  # If no lines in chunk
+        return ccf_out
+    end
+
+    for i in 1:size(flux, 2)
+        ccf_out[:,i] = ccf_1D(λ, flux[:,i], plan)
+    end
+    return ccf_out
+end
+
+"""
     `ccf_1D( λs, fluxes, vars; ccf_plan )`
 
 Compute the cross correlation function of a spectrum with a mask and its variance.

--- a/src/ccf/calc_ccf.jl
+++ b/src/ccf/calc_ccf.jl
@@ -292,12 +292,11 @@ end
 # Returns:
 - 2-d array of size (length(calc_ccf_v_grid(plan)), size(flux, 2))
 """
-function ccf_1D(λ::A2, flux::A3, #line_list::ALL, #mask_shape1::A3
+function ccf_1D_test(λ::A2, flux::A3,
                 plan::PlanT = BasicCCFPlan() ) where {
-                #; mask_shape::ACMS = TopHatCCFMask(), plan::PlanT = BasicCCFPlan() ) where {
-                T1<:Real, A1<:AbstractArray{T1,1}, T2<:Real, A2<:AbstractArray{T2,1}, T3<:Real, A3<:AbstractArray{T3,2},
-                #ALL<:AbstractLineList, ACMS<:AbstractCCFMaskShape, AP<:AbstractCCFPlan }
-                PlanT<:AbstractCCFPlan } # ALL<:AbstractLineList, ACMS<:AbstractCCFMaskShape }
+                T2<:Real, A2<:AbstractArray{T2,1},
+                T3<:Real, A3<:AbstractArray{T3,2},
+                PlanT<:AbstractCCFPlan }
     @assert ndims(λ) == 1
     @assert ndims(flux) == 2
     @assert length(λ) == size(flux, 1)
@@ -307,8 +306,10 @@ function ccf_1D(λ::A2, flux::A3, #line_list::ALL, #mask_shape1::A3
         return ccf_out
     end
 
+    ccf_temp = zeros(len_v_grid)
     for i in 1:size(flux, 2)
-        ccf_out[:,i] = ccf_1D(λ, flux[:,i], plan)
+        ccf_1D!(ccf_temp, λ, flux[:,i], plan)
+        ccf_out[:,i] = ccf_temp
     end
     return ccf_out
 end


### PR DESCRIPTION
Having a method that computes CCFs for all 1D slices in an array of spectra is useful for my particular workflow, so I just added this simple method. (I don't think it was there before). 